### PR TITLE
fix(processor): change to use CustomFieldsDraft

### DIFF
--- a/processor/src/services/MockPaymentService.ts
+++ b/processor/src/services/MockPaymentService.ts
@@ -5,7 +5,7 @@ import {
   TransactionType,
   TransactionState,
 } from '@commercetools/connect-payments-sdk';
-import type { CustomFieldsData } from '@commercetools/connect-payments-sdk/dist/commercetools/types/payment.type';
+import type { CustomFieldsDraft } from '@commercetools/connect-payments-sdk';
 import {
   CancelPaymentRequest,
   CapturePaymentRequest,
@@ -220,8 +220,11 @@ export class MockPaymentService extends AbstractPaymentService {
     });
 
     const pspReference = randomUUID().toString();
-    const customFields: CustomFieldsData = {
-      typeKey: launchpadPurchaseOrderCustomType.key,
+    const customFields: CustomFieldsDraft = {
+      type: {
+        typeId: 'type',
+        key: launchpadPurchaseOrderCustomType.key,
+      },
       fields: {
         [launchpadPurchaseOrderCustomType.purchaseOrderNumber]: request.data.paymentMethod.poNumber,
         [launchpadPurchaseOrderCustomType.invoiceMemo]: request.data.paymentMethod.invoiceMemo,


### PR DESCRIPTION
- In the latest version of `payment-sdk` it introduced `CustomFieldsDraft` instead of `CustomFieldsData` for `updatePayment` function. This fix is to cope with the breaking change

- This fix applies to the dependabot PR
https://github.com/commercetools/connect-payment-integration-braintree/pull/25