### PR TITLE
fix: initialise paymentReference in Enabler instantiation

### DIFF
--- a/enabler/src/components/BaseComponent.ts
+++ b/enabler/src/components/BaseComponent.ts
@@ -21,6 +21,7 @@ export abstract class BaseComponent implements PaymentComponent {
 	protected processorUrl: BaseOptions["processorUrl"];
 	protected sessionId: BaseOptions["sessionId"];
 	protected environment: BaseOptions["environment"];
+	protected paymentReference?: BaseOptions["paymentReference"];
 	protected onComplete: (result: PaymentResult) => void;
 	protected onError: (error?: any) => void;
 
@@ -30,6 +31,7 @@ export abstract class BaseComponent implements PaymentComponent {
 		this.processorUrl = baseOptions.processorUrl;
 		this.sessionId = baseOptions.sessionId;
 		this.environment = baseOptions.environment;
+		this.paymentReference = baseOptions.paymentReference;
 		this.onComplete = baseOptions.onComplete;
 		this.onError = baseOptions.onError;
 	}

--- a/enabler/src/components/payment-methods/card/Card.ts
+++ b/enabler/src/components/payment-methods/card/Card.ts
@@ -111,11 +111,11 @@ export class Card extends BaseComponent {
 			this.onError(error);
 			return;
 		}
-
+		
 		const request = {
 			nonce: payload.nonce,
 			paymentMethodType: "card",
-			paymentReference: payload.description,
+			paymentReference: this.paymentReference,
 		};
 		try {
 			const response = await fetch(this.processorUrl + "/payment", {

--- a/enabler/src/payment-enabler/BaseOptions.ts
+++ b/enabler/src/payment-enabler/BaseOptions.ts
@@ -10,6 +10,7 @@ export type BaseOptions = {
 	sessionId: string;
 	environment: string;
 	locale?: string;
+	paymentReference?: string;
 	onComplete: (result: PaymentResult) => void;
 	onError: (error?: any) => void;
 };

--- a/enabler/src/payment-enabler/BraintreePaymentEnabler.ts
+++ b/enabler/src/payment-enabler/BraintreePaymentEnabler.ts
@@ -16,7 +16,7 @@ export class BraintreePaymentEnabler implements PaymentEnabler {
 		this.setupData = BraintreePaymentEnabler._Setup(options);
 	}
 
-	private static getBraintreeToken = async (options: EnablerOptions): Promise<string> => {
+	private static getBraintreeToken = async (options: EnablerOptions): Promise<{ clientToken: string, paymentReference: string }> => {
 		let response!: Response;
 		try {
 			response = await fetch(`${options.processorUrl}/init`, {
@@ -32,21 +32,13 @@ export class BraintreePaymentEnabler implements PaymentEnabler {
 			console.log("response: ", response);
 		}
 
-		const token: { clientToken: string } = await response.json();
-		return token.clientToken;
+		const initResponse: { clientToken: string, paymentReference: string } = await response.json();
+		return { clientToken: initResponse.clientToken, paymentReference: initResponse.paymentReference };
 	};
 
 	private static _Setup = async (options: EnablerOptions): Promise<{ baseOptions: BaseOptions }> => {
-		// Fetch SDK config from processor if needed, for example:
 
-		// const configResponse = await fetch(instance.processorUrl + '/config', {
-		//   method: 'GET',
-		//   headers: { 'Content-Type': 'application/json', 'X-Session-Id': options.sessionId },
-		// });
-
-		// const configJson = await configResponse.json();
-
-		const clientToken = await BraintreePaymentEnabler.getBraintreeToken(options);
+		const { clientToken, paymentReference } = await BraintreePaymentEnabler.getBraintreeToken(options);
 
 		const sdkOptions = {
 			environment: "test",
@@ -62,6 +54,7 @@ export class BraintreePaymentEnabler implements PaymentEnabler {
 				processorUrl: options.processorUrl,
 				sessionId: options.sessionId,
 				environment: sdkOptions.environment,
+				paymentReference,
 				onComplete: options.onComplete || (() => {}),
 				onError: options.onError || (() => {}),
 			},

--- a/processor/src/clients/index.ts
+++ b/processor/src/clients/index.ts
@@ -1,3 +1,3 @@
 import { BraintreeClient } from "./BraintreeClient";
 
-export { BraintreeClient }
+export { BraintreeClient };

--- a/processor/src/dtos/payment/BraintreeInitResponseSchema.ts
+++ b/processor/src/dtos/payment/BraintreeInitResponseSchema.ts
@@ -2,4 +2,5 @@ import { Type } from "@sinclair/typebox";
 
 export const BraintreeInitResponseSchema = Type.Object({
 	clientToken: Type.String(),
+	paymentReference: Type.String(),
 });

--- a/processor/test/services/BraintreePaymentService.test.ts
+++ b/processor/test/services/BraintreePaymentService.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach, jest, beforeEach } from "@jest/globals";
-import { ConfigResponse, ModifyPayment, /*  StatusResponse*/ } from "../../src/services/types/operations";
+import { ConfigResponse, ModifyPayment /*  StatusResponse*/ } from "../../src/services/types/operations";
 import { paymentSDK } from "../../src/sdk/paymentSDK";
 import { DefaultPaymentService } from "@commercetools/connect-payments-sdk/dist/commercetools/services/ct-payment.service";
 
@@ -18,8 +18,6 @@ import {
 import { /* CreatePaymentRequest, */ BraintreePaymentServiceOptions } from "../../src/services/types/payment";
 import { AbstractPaymentService } from "../../src/services/AbstractPaymentService";
 import { BraintreePaymentService } from "../../src/services/BraintreePaymentService";
-
-
 
 // import * as FastifyContext from '../../src/libs/fastify/context';
 // import * as StatusHandler from '@commercetools/connect-payments-sdk/dist/api/handlers/status.handler';


### PR DESCRIPTION
- create CoCo payment when the Enabler class is instantiated, and keep the `paymentReference` inside the Enabler class
- send the `paymentReference` as a request attribute to `/payment` API