### PR TITLE
fix(processor): modify the transaction state after void Braintree payment

### DIFF
--- a/processor/src/dtos/operations/PaymentIntentResponseSchema.ts
+++ b/processor/src/dtos/operations/PaymentIntentResponseSchema.ts
@@ -5,4 +5,5 @@ const PaymentModificationSchema = Type.Enum(PaymentModificationStatus);
 
 export const PaymentIntentResponseSchema = Type.Object({
 	outcome: PaymentModificationSchema,
+	pspReference: Type.String()
 });

--- a/processor/src/services/BraintreePaymentService.ts
+++ b/processor/src/services/BraintreePaymentService.ts
@@ -308,10 +308,9 @@ export class BraintreePaymentService extends AbstractPaymentService {
 
 		logger.info(`Payment modification completed.`, {
 			paymentId: cancelPaymentRequest.payment.id,
-			action: "capturePayment",
+			action,
 			result: response.outcome,
 		});
-
 		return {
 			outcome: response.outcome,
 			pspReference: response.pspReference,
@@ -432,7 +431,7 @@ export class BraintreePaymentService extends AbstractPaymentService {
 				),
 			},
 		});
-
-		return { outcome: PaymentModificationStatus.RECEIVED, pspReference: response.transaction.id };
+		const outcome = response.success ? PaymentModificationStatus.APPROVED : PaymentModificationStatus.REJECTED
+		return { outcome, pspReference: response.transaction.id };
 	}
 }


### PR DESCRIPTION
Change the status from RECEIVED to APPROVED since braintree void the transaction immeidately without processing time.